### PR TITLE
feat: add filter and sort controls to feed page

### DIFF
--- a/client/src/pages/FeedPage.jsx
+++ b/client/src/pages/FeedPage.jsx
@@ -5,6 +5,9 @@ import EntryModal from "../components/EntryModal";
 export default function FeedPage() {
   const [entries, setEntries] = useState([]);
   const [selectedEntry, setSelectedEntry] = useState(null);
+  const [companyFilter, setCompanyFilter] = useState("");
+  const [jobTypeFilter, setJobTypeFilter] = useState("");
+  const [sortOrder, setSortOrder] = useState("newest");
 
   useEffect(() => {
     const fetchEntries = async () => {
@@ -19,14 +22,81 @@ export default function FeedPage() {
     fetchEntries();
   }, []);
 
+  const uniqueCompanies = [...new Set(entries.map((entry) => entry.company_name))];
+
+  const filteredAndSortedEntries = [...entries]
+    .filter((entry) => {
+      const matchesCompany =
+        companyFilter === "" || entry.company_name === companyFilter;
+
+      const matchesJobType =
+        jobTypeFilter === "" || entry.job_type === jobTypeFilter;
+
+      return matchesCompany && matchesJobType;
+    })
+    .sort((a, b) => {
+      const dateA = new Date(a.layoff_date);
+      const dateB = new Date(b.layoff_date);
+
+      if (sortOrder === "newest") {
+        return dateB - dateA;
+      } else {
+        return dateA - dateB;
+      }
+    });
+
   return (
     <div style={{ marginTop: "2rem" }}>
       <h1>Feed Page</h1>
 
-      {entries.length === 0 ? (
-        <p>No entries yet.</p>
+      <div
+        style={{
+          display: "flex",
+          gap: "1rem",
+          flexWrap: "wrap",
+          marginBottom: "1.5rem",
+          alignItems: "center",
+        }}
+      >
+        <select
+          value={companyFilter}
+          onChange={(e) => setCompanyFilter(e.target.value)}
+          style={{ padding: "0.5rem", borderRadius: "6px" }}
+        >
+          <option value="">All Companies</option>
+          {uniqueCompanies.map((company) => (
+            <option key={company} value={company}>
+              {company}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={jobTypeFilter}
+          onChange={(e) => setJobTypeFilter(e.target.value)}
+          style={{ padding: "0.5rem", borderRadius: "6px" }}
+        >
+          <option value="">All Job Types</option>
+          <option value="Full-time">Full-time</option>
+          <option value="Contract">Contract</option>
+          <option value="Part-time">Part-time</option>
+          <option value="Internship">Internship</option>
+        </select>
+
+        <select
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value)}
+          style={{ padding: "0.5rem", borderRadius: "6px" }}
+        >
+          <option value="newest">Newest First</option>
+          <option value="oldest">Oldest First</option>
+        </select>
+      </div>
+
+      {filteredAndSortedEntries.length === 0 ? (
+        <p>No matching entries found.</p>
       ) : (
-        entries.map((entry) => (
+        filteredAndSortedEntries.map((entry) => (
           <div
             key={entry.id}
             onClick={() => setSelectedEntry(entry)}


### PR DESCRIPTION
## Summary
Adds filter and sort controls to the Feed page so users can browse layoff stories more easily.

## Changes
- Added company filter dropdown
- Added job type filter dropdown
- Added sort dropdown for newest and oldest layoff date
- Rendered filtered and sorted feed results dynamically
- Kept feed card and entry modal behavior working with filtered results

## Testing
- Verified company filtering works
- Verified job type filtering works
- Verified combining company + job type filters works
- Verified newest/oldest sorting updates result order correctly
- Verified filtered entries still open correctly in the entry modal
- Verified resetting filters manually restores all entries

## Notes
This PR focuses on the Feed page MVP browsing experience and builds on the existing feed + modal functionality.
Tested locally with Google, Internship, Newest First and Oldest First combinations.
<img width="1512" height="982" alt="Screenshot 2026-04-20 at 8 43 53 PM" src="https://github.com/user-attachments/assets/5a05f6fd-cbd5-4f30-9db8-1f364b0f9b25" />
<img width="1512" height="982" alt="Screenshot 2026-04-20 at 8 43 56 PM" src="https://github.com/user-attachments/assets/48897577-84d5-438b-8001-0c196f615c2f" />
<img width="1512" height="982" alt="Screenshot 2026-04-20 at 8 43 59 PM" src="https://github.com/user-attachments/assets/46ec5087-2792-4ed7-88ae-a24f5ba14048" />
<img width="1512" height="982" alt="Screenshot 2026-04-20 at 8 44 11 PM" src="https://github.com/user-attachments/assets/b49e49d2-12d4-482d-83e0-4dd8b4f278e0" />
<img width="1512" height="982" alt="Screenshot 2026-04-20 at 8 48 28 PM" src="https://github.com/user-attachments/assets/4ad91222-b83c-4da7-9a47-05e421f377d7" />
<img width="1512" height="982" alt="Screenshot 2026-04-20 at 8 48 30 PM" src="https://github.com/user-attachments/assets/197626e3-46db-41c8-831a-7e02ecd1f3f6" />
