### PR TITLE
Polish feed page UI and add search controls

### DIFF
--- a/client/src/components/FeedControls.jsx
+++ b/client/src/components/FeedControls.jsx
@@ -1,0 +1,78 @@
+export default function FeedControls({
+  companyFilter,
+  setCompanyFilter,
+  jobTypeFilter,
+  setJobTypeFilter,
+  sortOrder,
+  setSortOrder,
+  uniqueCompanies,
+  onReset,
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: "1rem",
+        flexWrap: "wrap",
+        marginBottom: "1.5rem",
+        alignItems: "center",
+      }}
+    >
+      <select
+        value={companyFilter}
+        onChange={(e) => setCompanyFilter(e.target.value)}
+        style={{ padding: "0.5rem", borderRadius: "6px" }}
+      >
+        <option value="">All Companies</option>
+        {uniqueCompanies.map((company) => (
+          <option key={company} value={company}>
+            {company}
+          </option>
+        ))}
+      </select>
+
+      <select
+        value={jobTypeFilter}
+        onChange={(e) => setJobTypeFilter(e.target.value)}
+        style={{ padding: "0.5rem", borderRadius: "6px" }}
+      >
+        <option value="">All Job Types</option>
+        <option value="Full-time">Full-time</option>
+        <option value="Contract">Contract</option>
+        <option value="Part-time">Part-time</option>
+        <option value="Internship">Internship</option>
+      </select>
+
+      <select
+        value={sortOrder}
+        onChange={(e) => setSortOrder(e.target.value)}
+        style={{ padding: "0.5rem", borderRadius: "6px" }}
+      >
+        <option value="newest">Newest First</option>
+        <option value="oldest">Oldest First</option>
+      </select>
+
+      <button
+  onClick={onReset}
+  style={{
+    padding: "0.5rem 0.75rem",
+    borderRadius: "6px",
+    border: "none",
+    backgroundColor: "#2563eb",
+    color: "white",
+    fontWeight: 500,
+    cursor: "pointer",
+    transition: "background-color 0.2s ease",
+  }}
+  onMouseEnter={(e) => {
+    e.target.style.backgroundColor = "#1d4ed8";
+  }}
+  onMouseLeave={(e) => {
+    e.target.style.backgroundColor = "#2563eb";
+  }}
+>
+  Reset Filters
+</button>
+    </div>
+  );
+}

--- a/client/src/components/FeedControls.jsx
+++ b/client/src/components/FeedControls.jsx
@@ -8,20 +8,37 @@ export default function FeedControls({
   uniqueCompanies,
   onReset,
 }) {
+  const isDefault =
+    companyFilter === "" &&
+    jobTypeFilter === "" &&
+    sortOrder === "newest";
+
   return (
     <div
       style={{
         display: "flex",
         gap: "1rem",
         flexWrap: "wrap",
-        marginBottom: "1.5rem",
         alignItems: "center",
+        padding: "1rem",
+        borderRadius: "14px",
+        backgroundColor: "#ffffff",
+        border: "1px solid #e5e7eb",
+        boxShadow: "0 4px 14px rgba(15, 23, 42, 0.05)",
+        marginBottom: "1.5rem",
       }}
     >
       <select
         value={companyFilter}
         onChange={(e) => setCompanyFilter(e.target.value)}
-        style={{ padding: "0.5rem", borderRadius: "6px" }}
+        style={{
+          padding: "0.75rem 0.9rem",
+          borderRadius: "10px",
+          border: "1px solid #cbd5e1",
+          backgroundColor: "#ffffff",
+          color: "#0f172a",
+          fontSize: "0.95rem",
+        }}
       >
         <option value="">All Companies</option>
         {uniqueCompanies.map((company) => (
@@ -34,7 +51,14 @@ export default function FeedControls({
       <select
         value={jobTypeFilter}
         onChange={(e) => setJobTypeFilter(e.target.value)}
-        style={{ padding: "0.5rem", borderRadius: "6px" }}
+        style={{
+          padding: "0.75rem 0.9rem",
+          borderRadius: "10px",
+          border: "1px solid #cbd5e1",
+          backgroundColor: "#ffffff",
+          color: "#0f172a",
+          fontSize: "0.95rem",
+        }}
       >
         <option value="">All Job Types</option>
         <option value="Full-time">Full-time</option>
@@ -46,33 +70,36 @@ export default function FeedControls({
       <select
         value={sortOrder}
         onChange={(e) => setSortOrder(e.target.value)}
-        style={{ padding: "0.5rem", borderRadius: "6px" }}
+        style={{
+          padding: "0.75rem 0.9rem",
+          borderRadius: "10px",
+          border: "1px solid #cbd5e1",
+          backgroundColor: "#ffffff",
+          color: "#0f172a",
+          fontSize: "0.95rem",
+        }}
       >
         <option value="newest">Newest First</option>
         <option value="oldest">Oldest First</option>
       </select>
 
       <button
-  onClick={onReset}
-  style={{
-    padding: "0.5rem 0.75rem",
-    borderRadius: "6px",
-    border: "none",
-    backgroundColor: "#2563eb",
-    color: "white",
-    fontWeight: 500,
-    cursor: "pointer",
-    transition: "background-color 0.2s ease",
-  }}
-  onMouseEnter={(e) => {
-    e.target.style.backgroundColor = "#1d4ed8";
-  }}
-  onMouseLeave={(e) => {
-    e.target.style.backgroundColor = "#2563eb";
-  }}
->
-  Reset Filters
-</button>
+        onClick={onReset}
+        disabled={isDefault}
+        style={{
+          padding: "0.75rem 1rem",
+          borderRadius: "10px",
+          border: "none",
+          backgroundColor: isDefault ? "#94a3b8" : "#2563eb",
+          color: "white",
+          fontWeight: 600,
+          cursor: isDefault ? "not-allowed" : "pointer",
+          opacity: isDefault ? 0.7 : 1,
+          transition: "background-color 0.2s ease",
+        }}
+      >
+        Reset Filters
+      </button>
     </div>
   );
 }

--- a/client/src/components/FeedControls.jsx
+++ b/client/src/components/FeedControls.jsx
@@ -5,21 +5,20 @@ export default function FeedControls({
   setJobTypeFilter,
   sortOrder,
   setSortOrder,
+  searchTerm,
+  setSearchTerm,
   uniqueCompanies,
   onReset,
 }) {
   const isDefault =
     companyFilter === "" &&
     jobTypeFilter === "" &&
-    sortOrder === "newest";
+    sortOrder === "newest" &&
+    searchTerm === "";
 
   return (
     <div
       style={{
-        display: "flex",
-        gap: "1rem",
-        flexWrap: "wrap",
-        alignItems: "center",
         padding: "1rem",
         borderRadius: "14px",
         backgroundColor: "#ffffff",
@@ -28,78 +27,106 @@ export default function FeedControls({
         marginBottom: "1.5rem",
       }}
     >
-      <select
-        value={companyFilter}
-        onChange={(e) => setCompanyFilter(e.target.value)}
-        style={{
-          padding: "0.75rem 0.9rem",
-          borderRadius: "10px",
-          border: "1px solid #cbd5e1",
-          backgroundColor: "#ffffff",
-          color: "#0f172a",
-          fontSize: "0.95rem",
-        }}
-      >
-        <option value="">All Companies</option>
-        {uniqueCompanies.map((company) => (
-          <option key={company} value={company}>
-            {company}
-          </option>
-        ))}
-      </select>
+      <div style={{ marginBottom: "1rem" }}>
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Search by company, role, or keyword..."
+          style={{
+            width: "100%",
+            padding: "0.85rem 1rem",
+            borderRadius: "10px",
+            border: "1px solid #cbd5e1",
+            backgroundColor: "#ffffff",
+            color: "#0f172a",
+            fontSize: "0.95rem",
+            boxSizing: "border-box",
+          }}
+        />
+      </div>
 
-      <select
-        value={jobTypeFilter}
-        onChange={(e) => setJobTypeFilter(e.target.value)}
+      <div
         style={{
-          padding: "0.75rem 0.9rem",
-          borderRadius: "10px",
-          border: "1px solid #cbd5e1",
-          backgroundColor: "#ffffff",
-          color: "#0f172a",
-          fontSize: "0.95rem",
+          display: "flex",
+          gap: "1rem",
+          flexWrap: "wrap",
+          alignItems: "center",
         }}
       >
-        <option value="">All Job Types</option>
-        <option value="Full-time">Full-time</option>
-        <option value="Contract">Contract</option>
-        <option value="Part-time">Part-time</option>
-        <option value="Internship">Internship</option>
-      </select>
+        <select
+          value={companyFilter}
+          onChange={(e) => setCompanyFilter(e.target.value)}
+          style={{
+            padding: "0.75rem 0.9rem",
+            borderRadius: "10px",
+            border: "1px solid #cbd5e1",
+            backgroundColor: "#ffffff",
+            color: "#0f172a",
+            fontSize: "0.95rem",
+          }}
+        >
+          <option value="">All Companies</option>
+          {uniqueCompanies.map((company) => (
+            <option key={company} value={company}>
+              {company}
+            </option>
+          ))}
+        </select>
 
-      <select
-        value={sortOrder}
-        onChange={(e) => setSortOrder(e.target.value)}
-        style={{
-          padding: "0.75rem 0.9rem",
-          borderRadius: "10px",
-          border: "1px solid #cbd5e1",
-          backgroundColor: "#ffffff",
-          color: "#0f172a",
-          fontSize: "0.95rem",
-        }}
-      >
-        <option value="newest">Newest First</option>
-        <option value="oldest">Oldest First</option>
-      </select>
+        <select
+          value={jobTypeFilter}
+          onChange={(e) => setJobTypeFilter(e.target.value)}
+          style={{
+            padding: "0.75rem 0.9rem",
+            borderRadius: "10px",
+            border: "1px solid #cbd5e1",
+            backgroundColor: "#ffffff",
+            color: "#0f172a",
+            fontSize: "0.95rem",
+          }}
+        >
+          <option value="">All Job Types</option>
+          <option value="Full-time">Full-time</option>
+          <option value="Contract">Contract</option>
+          <option value="Part-time">Part-time</option>
+          <option value="Internship">Internship</option>
+        </select>
 
-      <button
-        onClick={onReset}
-        disabled={isDefault}
-        style={{
-          padding: "0.75rem 1rem",
-          borderRadius: "10px",
-          border: "none",
-          backgroundColor: isDefault ? "#94a3b8" : "#2563eb",
-          color: "white",
-          fontWeight: 600,
-          cursor: isDefault ? "not-allowed" : "pointer",
-          opacity: isDefault ? 0.7 : 1,
-          transition: "background-color 0.2s ease",
-        }}
-      >
-        Reset Filters
-      </button>
+        <select
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value)}
+          style={{
+            padding: "0.75rem 0.9rem",
+            borderRadius: "10px",
+            border: "1px solid #cbd5e1",
+            backgroundColor: "#ffffff",
+            color: "#0f172a",
+            fontSize: "0.95rem",
+          }}
+        >
+          <option value="newest">Newest First</option>
+          <option value="oldest">Oldest First</option>
+        </select>
+
+        <button
+          onClick={onReset}
+          disabled={isDefault}
+          style={{
+            padding: "0.75rem 1rem",
+            borderRadius: "10px",
+            border: "none",
+            backgroundColor: isDefault ? "#94a3b8" : "#2563eb",
+            color: "white",
+            fontWeight: 600,
+            cursor: isDefault ? "not-allowed" : "pointer",
+            opacity: isDefault ? 0.7 : 1,
+            transition: "background-color 0.2s ease",
+          }}
+        >
+          Reset Filters
+        </button>
+      </div>
     </div>
   );
 }

--- a/client/src/hooks/useFeedFilters.js
+++ b/client/src/hooks/useFeedFilters.js
@@ -1,0 +1,48 @@
+import { useMemo, useState } from "react";
+
+export default function useFeedFilters(entries) {
+  const [companyFilter, setCompanyFilter] = useState("");
+  const [jobTypeFilter, setJobTypeFilter] = useState("");
+  const [sortOrder, setSortOrder] = useState("newest");
+
+  const handleResetFilters = () => {
+    setCompanyFilter("");
+    setJobTypeFilter("");
+    setSortOrder("newest");
+  };
+
+  const uniqueCompanies = useMemo(() => {
+    return [...new Set(entries.map((entry) => entry.company_name))];
+  }, [entries]);
+
+  const filteredAndSortedEntries = useMemo(() => {
+    return [...entries]
+      .filter((entry) => {
+        const matchesCompany =
+          companyFilter === "" || entry.company_name === companyFilter;
+
+        const matchesJobType =
+          jobTypeFilter === "" || entry.job_type === jobTypeFilter;
+
+        return matchesCompany && matchesJobType;
+      })
+      .sort((a, b) => {
+        const dateA = new Date(a.layoff_date);
+        const dateB = new Date(b.layoff_date);
+
+        return sortOrder === "newest" ? dateB - dateA : dateA - dateB;
+      });
+  }, [entries, companyFilter, jobTypeFilter, sortOrder]);
+
+  return {
+    companyFilter,
+    setCompanyFilter,
+    jobTypeFilter,
+    setJobTypeFilter,
+    sortOrder,
+    setSortOrder,
+    handleResetFilters,
+    uniqueCompanies,
+    filteredAndSortedEntries,
+  };
+}

--- a/client/src/hooks/useFeedFilters.js
+++ b/client/src/hooks/useFeedFilters.js
@@ -4,11 +4,13 @@ export default function useFeedFilters(entries) {
   const [companyFilter, setCompanyFilter] = useState("");
   const [jobTypeFilter, setJobTypeFilter] = useState("");
   const [sortOrder, setSortOrder] = useState("newest");
+  const [searchTerm, setSearchTerm] = useState("");
 
   const handleResetFilters = () => {
     setCompanyFilter("");
     setJobTypeFilter("");
     setSortOrder("newest");
+    setSearchTerm("");
   };
 
   const uniqueCompanies = useMemo(() => {
@@ -24,7 +26,15 @@ export default function useFeedFilters(entries) {
         const matchesJobType =
           jobTypeFilter === "" || entry.job_type === jobTypeFilter;
 
-        return matchesCompany && matchesJobType;
+        const normalizedSearch = searchTerm.toLowerCase();
+
+        const matchesSearch =
+          searchTerm === "" ||
+          entry.company_name?.toLowerCase().includes(normalizedSearch) ||
+          entry.role?.toLowerCase().includes(normalizedSearch) ||
+          entry.summary?.toLowerCase().includes(normalizedSearch);
+
+        return matchesCompany && matchesJobType && matchesSearch;
       })
       .sort((a, b) => {
         const dateA = new Date(a.layoff_date);
@@ -32,7 +42,7 @@ export default function useFeedFilters(entries) {
 
         return sortOrder === "newest" ? dateB - dateA : dateA - dateB;
       });
-  }, [entries, companyFilter, jobTypeFilter, sortOrder]);
+  }, [entries, companyFilter, jobTypeFilter, sortOrder, searchTerm]);
 
   return {
     companyFilter,
@@ -41,6 +51,8 @@ export default function useFeedFilters(entries) {
     setJobTypeFilter,
     sortOrder,
     setSortOrder,
+    searchTerm,
+    setSearchTerm,
     handleResetFilters,
     uniqueCompanies,
     filteredAndSortedEntries,

--- a/client/src/pages/FeedPage.jsx
+++ b/client/src/pages/FeedPage.jsx
@@ -15,6 +15,8 @@ export default function FeedPage() {
     setJobTypeFilter,
     sortOrder,
     setSortOrder,
+    searchTerm,
+    setSearchTerm,
     handleResetFilters,
     uniqueCompanies,
     filteredAndSortedEntries,
@@ -75,6 +77,8 @@ export default function FeedPage() {
           setJobTypeFilter={setJobTypeFilter}
           sortOrder={sortOrder}
           setSortOrder={setSortOrder}
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
           uniqueCompanies={uniqueCompanies}
           onReset={handleResetFilters}
         />
@@ -124,11 +128,13 @@ export default function FeedPage() {
                 e.currentTarget.style.transform = "translateY(-3px)";
                 e.currentTarget.style.boxShadow =
                   "0 10px 24px rgba(15, 23, 42, 0.08)";
+                e.currentTarget.style.borderColor = "#cbd5e1";
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.transform = "none";
                 e.currentTarget.style.boxShadow =
                   "0 6px 18px rgba(15, 23, 42, 0.04)";
+                e.currentTarget.style.borderColor = "#e5e7eb";
               }}
               style={{
                 border: "1px solid #e5e7eb",
@@ -143,14 +149,17 @@ export default function FeedPage() {
             >
               <h3
                 style={{
-                  marginBottom: "0.4rem",
-                  fontSize: "1.75rem",
-                  fontWeight: 600,
-                  color: "#6b7280",
-                  textAlign: "center",
+                  marginBottom: "0.5rem",
+                  fontSize: "1.5rem",
+                  fontWeight: 700,
+                  color: "#475569",
+                  textAlign: "left",
                 }}
               >
-                {entry.role} @ {entry.company_name}
+                {entry.role}{" "}
+                <span style={{ color: "#2563eb", fontWeight: 700 }}>
+                  @ {entry.company_name}
+                </span>
               </h3>
 
               <p
@@ -158,7 +167,8 @@ export default function FeedPage() {
                   color: "#475569",
                   marginBottom: "0.9rem",
                   fontSize: "1.05rem",
-                  textAlign: "center",
+                  lineHeight: 1.5,
+                  textAlign: "left",
                 }}
               >
                 {entry.summary || "No summary provided."}
@@ -167,9 +177,9 @@ export default function FeedPage() {
               <p
                 style={{
                   color: "#64748b",
-                  fontSize: "0.98rem",
-                  marginBottom: "0.9rem",
-                  textAlign: "center",
+                  fontSize: "0.95rem",
+                  marginBottom: "1rem",
+                  textAlign: "left",
                 }}
               >
                 {entry.location || "Unknown location"} •{" "}
@@ -183,17 +193,21 @@ export default function FeedPage() {
                   : "Unknown date"}
               </p>
 
-              <p
-                style={{
-                  marginTop: "0.5rem",
-                  color: "#2563eb",
-                  fontSize: "0.95rem",
-                  fontWeight: 600,
-                  textAlign: "center",
-                }}
-              >
-                View Details →
-              </p>
+              <div style={{ textAlign: "left" }}>
+                <span
+                  style={{
+                    display: "inline-block",
+                    padding: "0.55rem 0.9rem",
+                    backgroundColor: "#eff6ff",
+                    color: "#2563eb",
+                    borderRadius: "999px",
+                    fontSize: "0.9rem",
+                    fontWeight: 600,
+                  }}
+                >
+                  View Details →
+                </span>
+              </div>
             </div>
           ))
         )}

--- a/client/src/pages/FeedPage.jsx
+++ b/client/src/pages/FeedPage.jsx
@@ -34,83 +34,175 @@ export default function FeedPage() {
   }, []);
 
   return (
-    <div style={{ marginTop: "2rem" }}>
-      <h1>Feed Page</h1>
+    <div
+      style={{
+        minHeight: "100vh",
+        backgroundColor: "#f8fafc",
+        padding: "2rem 1rem",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "920px",
+          margin: "0 auto",
+        }}
+      >
+        <h1
+          style={{
+            fontSize: "2.5rem",
+            fontWeight: 700,
+            color: "#0f172a",
+            marginBottom: "0.35rem",
+          }}
+        >
+          Browse Layoff Stories
+        </h1>
 
-      <FeedControls
-        companyFilter={companyFilter}
-        setCompanyFilter={setCompanyFilter}
-        jobTypeFilter={jobTypeFilter}
-        setJobTypeFilter={setJobTypeFilter}
-        sortOrder={sortOrder}
-        setSortOrder={setSortOrder}
-        uniqueCompanies={uniqueCompanies}
-        onReset={handleResetFilters}
-      />
-
-      {filteredAndSortedEntries.length === 0 ? (
-        <p>
-          No results match your filters. Try adjusting your filters or resetting
-          them.
+        <p
+          style={{
+            color: "#64748b",
+            fontSize: "1rem",
+            marginBottom: "1.5rem",
+          }}
+        >
+          Real experiences shared by professionals across companies.
         </p>
-      ) : (
-        filteredAndSortedEntries.map((entry) => (
+
+        <FeedControls
+          companyFilter={companyFilter}
+          setCompanyFilter={setCompanyFilter}
+          jobTypeFilter={jobTypeFilter}
+          setJobTypeFilter={setJobTypeFilter}
+          sortOrder={sortOrder}
+          setSortOrder={setSortOrder}
+          uniqueCompanies={uniqueCompanies}
+          onReset={handleResetFilters}
+        />
+
+        {filteredAndSortedEntries.length === 0 ? (
           <div
-            key={entry.id}
-            onClick={() => setSelectedEntry(entry)}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = "translateY(-2px)";
-              e.currentTarget.style.boxShadow = "0 6px 12px rgba(0,0,0,0.1)";
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = "none";
-              e.currentTarget.style.boxShadow = "none";
-            }}
             style={{
-              border: "1px solid #ddd",
-              borderRadius: "8px",
-              padding: "1rem",
-              marginBottom: "1rem",
-              cursor: "pointer",
-              transition: "transform 0.15s ease, box-shadow 0.15s ease",
+              textAlign: "center",
+              padding: "2rem",
+              borderRadius: "16px",
+              backgroundColor: "#ffffff",
+              border: "1px solid #e5e7eb",
+              boxShadow: "0 6px 18px rgba(15, 23, 42, 0.04)",
             }}
           >
-            <h3>
-              {entry.role} @ {entry.company_name}
-            </h3>
-
-            <p>{entry.summary || "No summary provided."}</p>
-
-            <small>
-              {entry.location || "Unknown location"} •{" "}
-              {entry.job_type || "Unknown job type"} • Laid off:{" "}
-              {entry.layoff_date
-                ? new Date(entry.layoff_date).toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })
-                : "Unknown date"}
-            </small>
-
             <p
               style={{
-                marginTop: "0.75rem",
-                color: "#2563eb",
-                fontSize: "0.9rem",
-                fontWeight: 500,
+                marginBottom: "0.9rem",
+                color: "#334155",
+                fontSize: "1rem",
               }}
             >
-              Click to view full details
+              No results match your filters.
             </p>
-          </div>
-        ))
-      )}
 
-      <EntryModal
-        entry={selectedEntry}
-        onClose={() => setSelectedEntry(null)}
-      />
+            <button
+              onClick={handleResetFilters}
+              style={{
+                padding: "0.65rem 1rem",
+                borderRadius: "8px",
+                border: "none",
+                backgroundColor: "#2563eb",
+                color: "#ffffff",
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Reset Filters
+            </button>
+          </div>
+        ) : (
+          filteredAndSortedEntries.map((entry) => (
+            <div
+              key={entry.id}
+              onClick={() => setSelectedEntry(entry)}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = "translateY(-3px)";
+                e.currentTarget.style.boxShadow =
+                  "0 10px 24px rgba(15, 23, 42, 0.08)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = "none";
+                e.currentTarget.style.boxShadow =
+                  "0 6px 18px rgba(15, 23, 42, 0.04)";
+              }}
+              style={{
+                border: "1px solid #e5e7eb",
+                borderRadius: "16px",
+                padding: "1.5rem",
+                marginBottom: "1rem",
+                backgroundColor: "#ffffff",
+                boxShadow: "0 6px 18px rgba(15, 23, 42, 0.04)",
+                cursor: "pointer",
+                transition: "all 0.18s ease",
+              }}
+            >
+              <h3
+                style={{
+                  marginBottom: "0.4rem",
+                  fontSize: "1.75rem",
+                  fontWeight: 600,
+                  color: "#6b7280",
+                  textAlign: "center",
+                }}
+              >
+                {entry.role} @ {entry.company_name}
+              </h3>
+
+              <p
+                style={{
+                  color: "#475569",
+                  marginBottom: "0.9rem",
+                  fontSize: "1.05rem",
+                  textAlign: "center",
+                }}
+              >
+                {entry.summary || "No summary provided."}
+              </p>
+
+              <p
+                style={{
+                  color: "#64748b",
+                  fontSize: "0.98rem",
+                  marginBottom: "0.9rem",
+                  textAlign: "center",
+                }}
+              >
+                {entry.location || "Unknown location"} •{" "}
+                {entry.job_type || "Unknown job type"} •{" "}
+                {entry.layoff_date
+                  ? new Date(entry.layoff_date).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })
+                  : "Unknown date"}
+              </p>
+
+              <p
+                style={{
+                  marginTop: "0.5rem",
+                  color: "#2563eb",
+                  fontSize: "0.95rem",
+                  fontWeight: 600,
+                  textAlign: "center",
+                }}
+              >
+                View Details →
+              </p>
+            </div>
+          ))
+        )}
+
+        <EntryModal
+          entry={selectedEntry}
+          onClose={() => setSelectedEntry(null)}
+        />
+      </div>
     </div>
   );
 }

--- a/client/src/pages/FeedPage.jsx
+++ b/client/src/pages/FeedPage.jsx
@@ -1,13 +1,24 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import EntryModal from "../components/EntryModal";
+import FeedControls from "../components/FeedControls";
+import useFeedFilters from "../hooks/useFeedFilters";
 
 export default function FeedPage() {
   const [entries, setEntries] = useState([]);
   const [selectedEntry, setSelectedEntry] = useState(null);
-  const [companyFilter, setCompanyFilter] = useState("");
-  const [jobTypeFilter, setJobTypeFilter] = useState("");
-  const [sortOrder, setSortOrder] = useState("newest");
+
+  const {
+    companyFilter,
+    setCompanyFilter,
+    jobTypeFilter,
+    setJobTypeFilter,
+    sortOrder,
+    setSortOrder,
+    handleResetFilters,
+    uniqueCompanies,
+    filteredAndSortedEntries,
+  } = useFeedFilters(entries);
 
   useEffect(() => {
     const fetchEntries = async () => {
@@ -22,79 +33,26 @@ export default function FeedPage() {
     fetchEntries();
   }, []);
 
-  const uniqueCompanies = [...new Set(entries.map((entry) => entry.company_name))];
-
-  const filteredAndSortedEntries = [...entries]
-    .filter((entry) => {
-      const matchesCompany =
-        companyFilter === "" || entry.company_name === companyFilter;
-
-      const matchesJobType =
-        jobTypeFilter === "" || entry.job_type === jobTypeFilter;
-
-      return matchesCompany && matchesJobType;
-    })
-    .sort((a, b) => {
-      const dateA = new Date(a.layoff_date);
-      const dateB = new Date(b.layoff_date);
-
-      if (sortOrder === "newest") {
-        return dateB - dateA;
-      } else {
-        return dateA - dateB;
-      }
-    });
-
   return (
     <div style={{ marginTop: "2rem" }}>
       <h1>Feed Page</h1>
 
-      <div
-        style={{
-          display: "flex",
-          gap: "1rem",
-          flexWrap: "wrap",
-          marginBottom: "1.5rem",
-          alignItems: "center",
-        }}
-      >
-        <select
-          value={companyFilter}
-          onChange={(e) => setCompanyFilter(e.target.value)}
-          style={{ padding: "0.5rem", borderRadius: "6px" }}
-        >
-          <option value="">All Companies</option>
-          {uniqueCompanies.map((company) => (
-            <option key={company} value={company}>
-              {company}
-            </option>
-          ))}
-        </select>
-
-        <select
-          value={jobTypeFilter}
-          onChange={(e) => setJobTypeFilter(e.target.value)}
-          style={{ padding: "0.5rem", borderRadius: "6px" }}
-        >
-          <option value="">All Job Types</option>
-          <option value="Full-time">Full-time</option>
-          <option value="Contract">Contract</option>
-          <option value="Part-time">Part-time</option>
-          <option value="Internship">Internship</option>
-        </select>
-
-        <select
-          value={sortOrder}
-          onChange={(e) => setSortOrder(e.target.value)}
-          style={{ padding: "0.5rem", borderRadius: "6px" }}
-        >
-          <option value="newest">Newest First</option>
-          <option value="oldest">Oldest First</option>
-        </select>
-      </div>
+      <FeedControls
+        companyFilter={companyFilter}
+        setCompanyFilter={setCompanyFilter}
+        jobTypeFilter={jobTypeFilter}
+        setJobTypeFilter={setJobTypeFilter}
+        sortOrder={sortOrder}
+        setSortOrder={setSortOrder}
+        uniqueCompanies={uniqueCompanies}
+        onReset={handleResetFilters}
+      />
 
       {filteredAndSortedEntries.length === 0 ? (
-        <p>No matching entries found.</p>
+        <p>
+          No results match your filters. Try adjusting your filters or resetting
+          them.
+        </p>
       ) : (
         filteredAndSortedEntries.map((entry) => (
           <div
@@ -121,15 +79,18 @@ export default function FeedPage() {
               {entry.role} @ {entry.company_name}
             </h3>
 
-            <p>{entry.summary}</p>
+            <p>{entry.summary || "No summary provided."}</p>
 
             <small>
-              {entry.location} • {entry.job_type} • Laid off:{" "}
-              {new Date(entry.layoff_date).toLocaleDateString("en-US", {
-                year: "numeric",
-                month: "short",
-                day: "numeric",
-              })}
+              {entry.location || "Unknown location"} •{" "}
+              {entry.job_type || "Unknown job type"} • Laid off:{" "}
+              {entry.layoff_date
+                ? new Date(entry.layoff_date).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })
+                : "Unknown date"}
             </small>
 
             <p


### PR DESCRIPTION
## Summary
This PR improves the Feed page UI/UX and expands feed controls for browsing layoff stories.

## What changed
- added a search bar to the feed controls
- kept company filter, job type filter, and sort controls modular through `FeedControls`
- added reset filter behavior through `useFeedFilters`
- improved feed card layout and readability
- updated feed cards to use left-aligned content
- added blue accent styling for company names
- changed "View Details" into a pill-style CTA
- improved empty state messaging and reset behavior
- refined page spacing, background, and card styling for a more polished product feel

## Files touched
- `client/src/pages/FeedPage.jsx`
- `client/src/components/FeedControls.jsx`
- `client/src/hooks/useFeedFilters.js`

## Why
The feed was already functional, but this makes it feel much closer to a real product:
- easier to search
- easier to scan
- cleaner visual hierarchy
- better filtering UX

## Testing done
- verified feed loads entries from `/api/entries`
- verified company filter works
- verified job type filter works
- verified newest/oldest sort works
- verified search works for company, role, and summary keywords
- verified reset clears filters and search
- verified empty state appears correctly
- verified clicking a card still opens the entry modal

## Notes
This PR focuses on feed polish and usability improvements only. It does not change backend entry data behavior.
-Will revisit at later time to improve on ui/color more

<img width="1512" height="982" alt="Screenshot 2026-04-21 at 12 28 00 AM" src="https://github.com/user-attachments/assets/b0e94c93-368f-41e9-8820-05a71ebf910c" />
