### PR TITLE
feat: Login/Logout 

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -56,6 +56,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -263,29 +264,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -896,6 +874,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -942,6 +921,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1067,6 +1047,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1362,6 +1343,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2472,6 +2454,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2542,6 +2525,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2551,6 +2535,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2813,6 +2798,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2937,6 +2923,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,31 +1,101 @@
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
-import FeedPage from "./pages/FeedPage";
-import SubmitEntryPage from "./pages/SubmitEntryPage";
-import CompanyPage from "./pages/CompanyPage";
-import NotFound from "./pages/NotFound";
+import { useEffect, useState } from 'react';
+import { BrowserRouter, Link, Navigate, Route, Routes } from 'react-router-dom';
+import CompanyPage from './pages/CompanyPage';
+import FeedPage from './pages/FeedPage';
+import Login from './pages/Login';
+import NotFound from './pages/NotFound';
+import SubmitEntryPage from './pages/SubmitEntryPage';
+
+const API_URL = 'http://localhost:3001';
 
 export default function App() {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const getUser = async () => {
+      try {
+        const response = await fetch(`${API_URL}/auth/login/success`, {
+          credentials: 'include',
+        });
+        const json = await response.json();
+        if (json.success) setUser(json.user);
+      } catch (err) {
+        console.error('Failed to fetch user:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getUser();
+  }, []);
+
+  const logout = async () => {
+    await fetch(`${API_URL}/auth/logout`, { credentials: 'include' });
+    setUser(null);
+    window.location.href = '/login';
+  };
+
   return (
     <BrowserRouter>
-      <div style={{ maxWidth: "800px", margin: "0 auto", padding: "1rem" }}>
-        <h2 style={{ padding: "1rem 0" }}>LayoffLens</h2>
-
-        <nav
-          style={{
-            display: "flex",
-            gap: "1rem",
-            padding: "1rem 0",
-            borderBottom: "1px solid #ddd",
-          }}
-        >
-          <Link to="/">Feed</Link>
-          <Link to="/submit">Submit Entry</Link>
-        </nav>
+      <div style={{ maxWidth: '800px', margin: '0 auto', padding: '1rem' }}>
+        {user && (
+          <>
+            <h2 style={{ padding: '1rem 0' }}>LayoffLens</h2>
+            <nav
+              style={{
+                display: 'flex',
+                gap: '1rem',
+                padding: '1rem 0',
+                borderBottom: '1px solid #ddd',
+                alignItems: 'center',
+              }}
+            >
+              <Link to="/">Feed</Link>
+              <Link to="/submit">Submit Entry</Link>
+              <span
+                style={{
+                  marginLeft: 'auto',
+                  display: 'flex',
+                  gap: '1rem',
+                  alignItems: 'center',
+                }}
+              >
+                <img
+                  src={user.avatar_url}
+                  style={{ height: '32px', borderRadius: '50%' }}
+                />
+                <span>{user.username}</span>
+                <button onClick={logout}>Logout</button>
+              </span>
+            </nav>
+          </>
+        )}
 
         <Routes>
-          <Route path="/" element={<FeedPage />} />
-          <Route path="/submit" element={<SubmitEntryPage />} />
-          <Route path="/company/:companyName" element={<CompanyPage />} />
+          <Route path="/login" element={<Login apiUrl={API_URL} />} />
+          <Route
+            path="/"
+            element={
+              loading ? null : user ? <FeedPage /> : <Navigate to="/login" />
+            }
+          />
+          <Route
+            path="/submit"
+            element={
+              loading ? null : user ? (
+                <SubmitEntryPage />
+              ) : (
+                <Navigate to="/login" />
+              )
+            }
+          />
+          <Route
+            path="/company/:companyName"
+            element={
+              loading ? null : user ? <CompanyPage /> : <Navigate to="/login" />
+            }
+          />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,0 +1,17 @@
+export default function Login({ apiUrl }) {
+  const error = new URLSearchParams(window.location.search).get('error');
+
+  return (
+    <div style={{ textAlign: 'center', marginTop: '4rem' }}>
+      <h1>LayoffLens</h1>
+      {error && (
+        <p style={{ color: 'red', marginBottom: '1rem' }}>
+          Login failed. Please try again.
+        </p>
+      )}
+      <a href={`${apiUrl}/auth/github`}>
+        <button>Sign in with GitHub</button>
+      </a>
+    </div>
+  );
+}

--- a/server/config/auth.js
+++ b/server/config/auth.js
@@ -1,0 +1,38 @@
+import GitHubStrategy from 'passport-github2';
+import pool from './database.js';
+
+const options = {
+  clientID: process.env.GITHUB_CLIENT_ID,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  callbackURL: 'http://localhost:3001/auth/github/callback',
+};
+
+const verify = async (accessToken, refreshToken, profile, callback) => {
+  const {
+    _json: { id, login, avatar_url },
+  } = profile;
+
+  try {
+    const results = await pool.query(
+      'SELECT * FROM users WHERE github_id = $1',
+      [String(id)]
+    );
+    const user = results.rows[0];
+
+    if (!user) {
+      const newResults = await pool.query(
+        `INSERT INTO users (github_id, username, avatar_url)
+         VALUES($1, $2, $3)
+         RETURNING *`,
+        [String(id), login, avatar_url]
+      );
+      return callback(null, newResults.rows[0]);
+    }
+
+    return callback(null, user);
+  } catch (error) {
+    return callback(error);
+  }
+};
+
+export const GitHub = new GitHubStrategy(options, verify);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,10 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
+        "express-session": "^1.19.0",
         "nodemon": "^3.1.10",
+        "passport": "^0.7.0",
+        "passport-github2": "^0.1.12",
         "pg": "^8.13.1"
       }
     },
@@ -54,6 +57,15 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -413,6 +425,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "~0.7.2",
+        "cookie-signature": "~1.0.7",
+        "debug": "~2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "~5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -840,6 +890,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -873,6 +929,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -882,17 +947,80 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -1060,6 +1188,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1352,6 +1489,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,10 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
+    "express-session": "^1.19.0",
     "nodemon": "^3.1.10",
+    "passport": "^0.7.0",
+    "passport-github2": "^0.1.12",
     "pg": "^8.13.1"
   }
 }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import passport from 'passport';
+
+const router = express.Router();
+
+// Login success
+router.get('/login/success', (req, res) => {
+  if (req.user) {
+    res.status(200).json({ success: true, user: req.user });
+  } else {
+    res.status(401).json({ success: false, message: 'Not authenticated' });
+  }
+});
+
+// Login failed
+router.get('/login/failed', (req, res) => {
+  res.status(401).json({ success: false, message: 'Login failed' });
+});
+
+// Logout
+router.get('/logout', (req, res, next) => {
+  req.logout((err) => {
+    if (err) return next(err);
+
+    req.session.destroy((err) => {
+      res.clearCookie('connect.sid');
+      res.json({ status: 'logout', user: {} });
+    });
+  });
+});
+
+// Redirect to GitHub
+router.get(
+  '/github',
+  passport.authenticate('github', { scope: ['read:user'] })
+);
+
+// GitHub callback
+const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5175';
+router.get(
+  '/github/callback',
+  passport.authenticate('github', {
+    successRedirect: `${CLIENT_URL}/`,
+    failureRedirect: `${CLIENT_URL}/login?error=github_auth_failed`,
+  })
+);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,23 +1,69 @@
-import express from "express";
-import cors from "cors";
+import cors from 'cors';
+import express from 'express';
+import session from 'express-session';
+import passport from 'passport';
+import { GitHub } from './config/auth.js';
 
-import companyRoutes from "./routes/companies.js";
-import entryRoutes from "./routes/entries.js";
-import resetRoutes from "./routes/reset.js";
+import authRoutes from './routes/auth.js';
+import companyRoutes from './routes/companies.js';
+import entryRoutes from './routes/entries.js';
+import resetRoutes from './routes/reset.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-app.use(cors());
+// Session
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: true,
+  })
+);
+
+// CORS
+const allowedOrigins = [
+  'http://localhost:5173',
+  'http://localhost:5174',
+  'http://localhost:5175',
+];
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error(`CORS blocked: ${origin}`));
+      }
+    },
+    methods: 'GET,POST,PUT,DELETE,PATCH',
+    credentials: true,
+  })
+);
+
 app.use(express.json());
 
-app.get("/", (req, res) => {
-  res.send("LayoffLens API is running.");
+// Passport
+app.use(passport.initialize());
+app.use(passport.session());
+passport.use(GitHub);
+
+passport.serializeUser((user, done) => {
+  done(null, user);
 });
 
-app.use("/api/companies", companyRoutes);
-app.use("/api/entries", entryRoutes);
-app.use("/api/reset", resetRoutes);
+passport.deserializeUser((user, done) => {
+  done(null, user);
+});
+
+app.get('/', (req, res) => {
+  res.send('LayoffLens API is running.');
+});
+
+app.use('/api/companies', companyRoutes);
+app.use('/api/entries', entryRoutes);
+app.use('/api/reset', resetRoutes);
+app.use('/auth', authRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);


### PR DESCRIPTION
- Add Passport.js with GitHub OAuth2 strategy (passport-github2)
- Add express-session for session persistence
- Add /login page with "Sign in with GitHub" button and error display
- Add /auth routes: GitHub redirect, callback, login/success, logout
- Protect /, /submit, /company/:companyName routes behind auth check
- Fix CORS to allow multiple Vite dev server ports (5173–5175)
- Fix post-OAuth redirect to / instead of nonexistent /feed route
- Add loading state to prevent premature redirect before session resolves