### PR TITLE
feat: add stats dashboard page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useContext } from "react";
 import { BrowserRouter, Routes, Route, Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 import FeedPage from "./pages/FeedPage";
+import StatsPage from "./pages/StatsPage";
 import SubmitEntryPage from "./pages/SubmitEntryPage";
 import CompanyPage from "./pages/CompanyPage";
 import LoginPage from "./pages/LoginPage";
@@ -137,6 +138,7 @@ function AppShell() {
             </span>
           )}
           <Link to="/submit">Submit Entry</Link>
+          <Link to="/stats">Stats</Link>
         </nav>
 
         <Routes>
@@ -144,6 +146,7 @@ function AppShell() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/submit" element={<SubmitEntryPage />} />
           <Route path="/company/:companyName" element={<CompanyPage />} />
+          <Route path="/stats" element={<StatsPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/client/src/pages/StatsPage.css
+++ b/client/src/pages/StatsPage.css
@@ -1,0 +1,131 @@
+.stats-page {
+  padding: 1.5rem 0;
+}
+
+.stats-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 1.5rem;
+}
+
+/* Summary cards row */
+.stats-cards {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+}
+
+.stat-card {
+  flex: 1;
+  min-width: 160px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--card-shadow);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat-card-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-card-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.1;
+}
+
+.stat-card-sub {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  margin-top: 0.1rem;
+}
+
+/* Section row (used for side-by-side charts) */
+.stats-row {
+  display: flex;
+  gap: 1.5rem;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.stats-section {
+  flex: 1;
+  min-width: 280px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--card-shadow);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.stats-row > .stats-section {
+  margin-bottom: 0;
+}
+
+.stats-row {
+  margin-bottom: 1.5rem;
+}
+
+.stats-section-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 1rem;
+}
+
+.stats-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.stats-list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.stats-list-name {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.stats-list-count {
+  background: #1e293b;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  font-weight: 700;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  min-width: 28px;
+  text-align: center;
+}
+
+.stats-empty {
+  font-size: 0.9rem;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.stats-chart-subtitle {
+  font-size: 0.78rem;
+  color: #64748b;
+  margin: 0 0 1rem;
+}

--- a/client/src/pages/StatsPage.jsx
+++ b/client/src/pages/StatsPage.jsx
@@ -1,0 +1,234 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  Cell,
+  AreaChart,
+  Area,
+} from 'recharts';
+
+import Spinner from '../components/Spinner';
+import './StatsPage.css';
+
+/* ------------------ CONFIG ------------------ */
+
+const API_URL = 'http://localhost:3001/api/stats';
+
+const COLORS = ['#60a5fa', '#34d399', '#fbbf24', '#f472b6', '#a78bfa'];
+
+/* ------------------ MAIN PAGE ------------------ */
+
+export default function StatsPage() {
+  const { data, loading, error } = useStats();
+
+  if (loading) return <Spinner />;
+  if (error) return <ErrorMessage message={error} />;
+
+  return (
+    <div className="stats-page">
+      <h2 className="stats-title">LayoffLens Stats</h2>
+
+      <SummaryCards summary={data.summary} />
+
+      <TopCompaniesChart data={data.top_companies} />
+      <MonthlyTrendChart data={data.monthly_trend} />
+
+      <div className="stats-row">
+        <JobTypePie data={data.by_job_type} />
+        <IndustryBar data={data.by_industry} />
+      </div>
+    </div>
+  );
+}
+
+/* ------------------ DATA FETCHING ------------------ */
+
+// Custom hook = cleaner than useEffect inline
+function useStats() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function fetchStats() {
+      try {
+        const res = await axios.get(API_URL);
+        setData(res.data);
+      } catch (err) {
+        setError('Failed to load stats.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchStats();
+  }, []);
+
+  return { data, loading, error };
+}
+
+/* ------------------ SUMMARY ------------------ */
+
+function SummaryCards({ summary }) {
+  const total = summary.total_user_entries + summary.total_external_entries;
+
+  return (
+    <div className="stats-cards">
+      <StatCard
+        label="Total Entries"
+        value={total}
+        sub={`${summary.total_user_entries} community · ${summary.total_external_entries} news`}
+      />
+      <StatCard
+        label="Avg Severance"
+        value={formatWeeks(summary.avg_severance_weeks)}
+      />
+      <StatCard
+        label="Avg Job Search"
+        value={formatWeeks(summary.avg_job_search_weeks)}
+      />
+    </div>
+  );
+}
+
+function StatCard({ label, value, sub }) {
+  return (
+    <div className="stat-card">
+      <strong>{label}</strong>
+      <div>{value}</div>
+      {sub && <small>{sub}</small>}
+    </div>
+  );
+}
+
+/* ------------------ CHARTS ------------------ */
+
+function TopCompaniesChart({ data }) {
+  if (!data.length) return <Empty title="Top Companies" />;
+
+  return (
+    <ChartSection title="Top Companies">
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          {/* <CartesianGrid vertical={false} /> */}
+          <XAxis dataKey="company_name" />
+          <YAxis allowDecimals={false} />
+          <Tooltip cursor={false} />
+          <Bar dataKey="entry_count">
+            {data.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartSection>
+  );
+}
+
+function MonthlyTrendChart({ data }) {
+  if (!data.length) return <Empty title="Monthly Trend" />;
+
+  return (
+    <ChartSection title="Layoffs Over Time">
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart data={data}>
+          <CartesianGrid horizontal={false} vertical={false} />
+          <XAxis dataKey="month" />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <Legend />
+          <Line type="monotone" dataKey="count" stroke="#34d399" />
+          {/* <Area
+            type="monotone"
+            dataKey="count"
+            stroke="#34d399"
+            fill="#34d399"
+            fillOpacity={0.2}
+            
+          /> */}
+        </AreaChart>
+      </ResponsiveContainer>
+    </ChartSection>
+  );
+}
+
+function JobTypePie({ data }) {
+  if (!data.length) return <Empty title="Job Types" />;
+
+  return (
+    <ChartSection title="Job Types">
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart>
+          <Pie data={data} dataKey="count" nameKey="job_type">
+            {data.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </ChartSection>
+  );
+}
+
+function IndustryBar({ data }) {
+  if (!data.length) return <Empty title="Industries" />;
+
+  return (
+    <ChartSection title="Layoffs by Industry">
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          {/* <CartesianGrid vertical={false} /> */}
+          <XAxis dataKey="industry" />
+          <YAxis allowDecimals={false} />
+          <Tooltip cursor={false} />
+          <Bar dataKey="count" fill="#a78bfa">
+            {data.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartSection>
+  );
+}
+
+/* ------------------ HELPERS ------------------ */
+
+function formatWeeks(value) {
+  return value ? `${value} weeks` : 'N/A';
+}
+
+function ChartSection({ title, children }) {
+  return (
+    <section className="stats-section">
+      <h3>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function Empty({ title }) {
+  return (
+    <section className="stats-section">
+      <h3>{title}</h3>
+      <p>No data yet.</p>
+    </section>
+  );
+}
+
+function ErrorMessage({ message }) {
+  return <p style={{ color: 'red' }}>{message}</p>;
+}

--- a/server/controllers/StatsController.js
+++ b/server/controllers/StatsController.js
@@ -1,0 +1,69 @@
+import StatsModel from '../models/StatsModel.js';
+
+// Simple function instead of a class
+export const getStats = async (req, res) => {
+  try {
+    // Fetch all data at the same time
+    const results = await Promise.all([
+      StatsModel.getSummary(),
+      StatsModel.getExternalCount(),
+      StatsModel.getTopCompanies(),
+      StatsModel.getByJobType(),
+      StatsModel.getByIndustry(),
+      StatsModel.getMonthlyTrend(),
+    ]);
+
+    // Destructure results for clarity
+    const [
+      summary,
+      externalCount,
+      topCompanies,
+      byJobType,
+      byIndustry,
+      monthlyTrend,
+    ] = results;
+
+    // Build response step by step (easier to read)
+    const response = {
+      summary: {
+        total_user_entries: Number(summary.total_user_entries),
+        total_external_entries: Number(externalCount.total_external_entries),
+        avg_severance_weeks: summary.avg_severance_weeks
+          ? Number(summary.avg_severance_weeks)
+          : null,
+        avg_job_search_weeks: summary.avg_job_search_weeks
+          ? Number(summary.avg_job_search_weeks)
+          : null,
+      },
+
+      top_companies: topCompanies.map((item) => ({
+        company_name: item.company_name,
+        entry_count: Number(item.entry_count),
+      })),
+
+      by_job_type: byJobType.map((item) => ({
+        job_type: item.job_type,
+        count: Number(item.count),
+      })),
+
+      by_industry: byIndustry.map((item) => ({
+        industry: item.industry,
+        count: Number(item.count),
+      })),
+
+      monthly_trend: monthlyTrend.map((item) => ({
+        month: item.month,
+        count: Number(item.count),
+      })),
+    };
+
+    // Send response
+    res.status(200).json(response);
+  } catch (error) {
+    console.error('Error fetching stats:', error);
+
+    res.status(500).json({
+      error: 'Failed to fetch stats.',
+    });
+  }
+};

--- a/server/models/StatsModel.js
+++ b/server/models/StatsModel.js
@@ -1,0 +1,74 @@
+import pool from "../config/database.js";
+
+const StatsModel = {
+  async getSummary() {
+    const result = await pool.query(`
+      SELECT
+        COUNT(*) AS total_user_entries,
+        ROUND(AVG(severance_weeks) FILTER (WHERE severance_weeks IS NOT NULL), 1) AS avg_severance_weeks,
+        ROUND(AVG(job_search_weeks) FILTER (WHERE job_search_weeks IS NOT NULL), 1) AS avg_job_search_weeks
+      FROM entries;
+    `);
+    return result.rows[0];
+  },
+
+  async getExternalCount() {
+    const result = await pool.query(`
+      SELECT COUNT(*) AS total_external_entries
+      FROM external_entries;
+    `);
+    return result.rows[0];
+  },
+
+  async getTopCompanies(limit = 10) {
+    const result = await pool.query(
+      `
+      SELECT c.name AS company_name, COUNT(*) AS entry_count
+      FROM entries e
+      JOIN companies c ON e.company_id = c.id
+      GROUP BY c.name
+      ORDER BY entry_count DESC
+      LIMIT $1;
+    `,
+      [limit]
+    );
+    return result.rows;
+  },
+
+  async getByJobType() {
+    const result = await pool.query(`
+      SELECT job_type, COUNT(*) AS count
+      FROM entries
+      GROUP BY job_type
+      ORDER BY count DESC;
+    `);
+    return result.rows;
+  },
+
+  async getByIndustry() {
+    const result = await pool.query(`
+      SELECT COALESCE(i.name, 'Unknown') AS industry, COUNT(*) AS count
+      FROM entries e
+      JOIN companies c ON e.company_id = c.id
+      LEFT JOIN industries i ON c.industry_id = i.id
+      GROUP BY i.name
+      ORDER BY count DESC;
+    `);
+    return result.rows;
+  },
+
+  async getMonthlyTrend() {
+    const result = await pool.query(`
+      SELECT
+        TO_CHAR(DATE_TRUNC('month', layoff_date), 'YYYY-MM') AS month,
+        COUNT(*) AS count
+      FROM entries
+      WHERE layoff_date >= NOW() - INTERVAL '12 months'
+      GROUP BY month
+      ORDER BY month ASC;
+    `);
+    return result.rows;
+  },
+};
+
+export default StatsModel;

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -1,0 +1,8 @@
+import express from "express";
+import { getStats } from "../controllers/StatsController.js";
+
+const router = express.Router();
+
+router.get("/", getStats);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ import cors from "cors";
 import companyRoutes from "./routes/companies.js";
 import entryRoutes from "./routes/entries.js";
 import resetRoutes from "./routes/reset.js";
+import statsRoutes from "./routes/stats.js";
 import tagRoutes from "./routes/tags.js";
 import userProfileRoutes from "./routes/user-profiles.js";
 
@@ -21,6 +22,7 @@ app.get("/", (req, res) => {
 app.use("/api/companies", companyRoutes);
 app.use("/api/entries", entryRoutes);
 app.use("/api/reset", resetRoutes);
+app.use("/api/stats", statsRoutes);
 app.use("/api/tags", tagRoutes);
 app.use("/api/user-profiles", userProfileRoutes);
 


### PR DESCRIPTION
## Summary

- Adds a `/stats` page with a full analytics dashboard for LayoffLens community data
- New `GET /api/stats` backend endpoint aggregates 5 SQL queries in parallel
- Wires in Recharts for interactive charts; nav link added to the app header

## Changes

**Backend**
- `server/models/StatsModel.js` — SQL queries for summary totals, top companies, job type breakdown, industry breakdown, and monthly layoff trend
- `server/controllers/StatsController.js` — runs all queries via `Promise.all`, returns single JSON response
- `server/routes/stats.js` — registers `GET /api/stats`
- `server/server.js` — mounts stats route

**Frontend**
- `client/src/pages/StatsPage.jsx` — summary stat cards + 4 charts (top companies bar, layoffs over time area, job types pie, industry bar)
- `client/src/pages/StatsPage.css` — card and chart styles using existing design tokens (`--surface`, `--border`, `--card-shadow`)
- `client/src/App.jsx` — added `Stats` nav link and `/stats` route
- `client/package.json` — added `recharts`
